### PR TITLE
Add Prettier code style badge and Instagram link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@
   <a href="https://www.npmjs.com/get-npm">
     <img src="https://img.shields.io/badge/npm-%3E%3D6.4.1-lightgrey.svg" alt="npm" />
   </a>
+  <a href="https://github.com/prettier/prettier">
+    <img src="https://img.shields.io/badge/code_style-prettier-ff69b4.svg" alt="code style: prettier" />
+  </a>
 </div>
 
 <br />
@@ -23,7 +26,7 @@ Welcome! This repository houses all of the assets required to build the website 
 
 ##### Follow us
 
-| 🖥 [Website](https://ceadoor.github.io/cea.ac.in/) | 💬 [Slack](https://ceadoor.slack.com/) | 🚀 [Blog](#) | 🐥 [Twitter](#) |
+| 🖥 [Website](https://ceadoor.github.io/cea.ac.in/) | 💬 [Slack](https://ceadoor.slack.com/) | 🚀 [Blog](#) | 🐥 [Twitter](#) | 📷 [Instagram](#) |
 
 
 --------


### PR DESCRIPTION
Close #139.

Please note the Instagram link in the `README.md` is a placeholder and will need to be replaced by the actual link. Having not found the official Instagram page, I have left the link blank (in the same way the links for the blog and the Twitter page are currently).

Hope it helps! 😃 