### PR TITLE
fix: automatically pick up html files within source directory within the webpack config.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -753,6 +753,11 @@
       "integrity": "sha1-ECyenpAF0+fjgpvwxPok7oYu6bk=",
       "dev": true
     },
+    "async": {
+      "version": "1.5.2",
+      "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+    },
     "async-each": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
@@ -3492,8 +3497,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
+            "delegates": "1.0.0",
+            "readable-stream": "2.3.6"
           }
         },
         "balanced-match": {
@@ -3506,7 +3511,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "balanced-match": "^1.0.0",
+            "balanced-match": "1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -3570,7 +3575,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "2.2.4"
           }
         },
         "fs.realpath": {
@@ -3585,14 +3590,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
+            "aproba": "1.2.0",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
           }
         },
         "glob": {
@@ -3601,12 +3606,12 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "has-unicode": {
@@ -3621,7 +3626,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safer-buffer": "^2.1.0"
+            "safer-buffer": "2.1.2"
           }
         },
         "ignore-walk": {
@@ -3630,7 +3635,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minimatch": "^3.0.4"
+            "minimatch": "3.0.4"
           }
         },
         "inflight": {
@@ -3639,8 +3644,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
           }
         },
         "inherits": {
@@ -3659,7 +3664,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "isarray": {
@@ -3673,7 +3678,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "minimist": {
@@ -3686,8 +3691,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "safe-buffer": "^5.1.1",
-            "yallist": "^3.0.0"
+            "safe-buffer": "5.1.1",
+            "yallist": "3.0.2"
           }
         },
         "minizlib": {
@@ -3696,7 +3701,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "2.2.4"
           }
         },
         "mkdirp": {
@@ -3719,9 +3724,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "^2.1.2",
-            "iconv-lite": "^0.4.4",
-            "sax": "^1.2.4"
+            "debug": "2.6.9",
+            "iconv-lite": "0.4.21",
+            "sax": "1.2.4"
           }
         },
         "node-pre-gyp": {
@@ -3730,16 +3735,16 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "detect-libc": "^1.0.2",
-            "mkdirp": "^0.5.1",
-            "needle": "^2.2.0",
-            "nopt": "^4.0.1",
-            "npm-packlist": "^1.1.6",
-            "npmlog": "^4.0.2",
-            "rc": "^1.1.7",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^4"
+            "detect-libc": "1.0.3",
+            "mkdirp": "0.5.1",
+            "needle": "2.2.0",
+            "nopt": "4.0.1",
+            "npm-packlist": "1.1.10",
+            "npmlog": "4.1.2",
+            "rc": "1.2.7",
+            "rimraf": "2.6.2",
+            "semver": "5.5.0",
+            "tar": "4.4.1"
           }
         },
         "nopt": {
@@ -3748,8 +3753,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
+            "abbrev": "1.1.1",
+            "osenv": "0.1.5"
           }
         },
         "npm-bundled": {
@@ -3764,8 +3769,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
+            "ignore-walk": "3.0.1",
+            "npm-bundled": "1.0.3"
           }
         },
         "npmlog": {
@@ -3774,10 +3779,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
           }
         },
         "number-is-nan": {
@@ -3796,7 +3801,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "wrappy": "1"
+            "wrappy": "1.0.2"
           }
         },
         "os-homedir": {
@@ -3817,8 +3822,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
           }
         },
         "path-is-absolute": {
@@ -3839,10 +3844,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "deep-extend": "^0.5.1",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
+            "deep-extend": "0.5.1",
+            "ini": "1.3.5",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -3859,13 +3864,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "rimraf": {
@@ -3874,7 +3879,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "7.1.2"
           }
         },
         "safe-buffer": {
@@ -3917,9 +3922,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         },
         "string_decoder": {
@@ -3928,7 +3933,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         },
         "strip-ansi": {
@@ -3936,7 +3941,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "strip-json-comments": {
@@ -3951,13 +3956,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "chownr": "^1.0.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.2.4",
-            "minizlib": "^1.1.0",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.1",
-            "yallist": "^3.0.2"
+            "chownr": "1.0.1",
+            "fs-minipass": "1.2.5",
+            "minipass": "2.2.4",
+            "minizlib": "1.1.0",
+            "mkdirp": "0.5.1",
+            "safe-buffer": "5.1.1",
+            "yallist": "3.0.2"
           }
         },
         "util-deprecate": {
@@ -3972,7 +3977,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "string-width": "^1.0.2"
+            "string-width": "1.0.2"
           }
         },
         "wrappy": {
@@ -4097,6 +4102,11 @@
           }
         }
       }
+    },
+    "glob-to-regexp": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.1.0.tgz",
+      "integrity": "sha1-4DadQmV4/UVtR9wjsJ3gXB2p6l0="
     },
     "global-modules-path": {
       "version": "2.3.0",
@@ -5640,6 +5650,15 @@
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.5.tgz",
       "integrity": "sha512-MmbQJ2MTESTjt3Gi/3yG1wGpIMhUfcIypUCGtTizFR9IiccFwxSpfp0vtIZlkFclEqERemxfnSdZEMR9VqqEFQ==",
       "dev": true
+    },
+    "node-glob": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/node-glob/-/node-glob-1.2.0.tgz",
+      "integrity": "sha1-UkD/7e/G1mPOhRXleWpNR6dQwNU=",
+      "requires": {
+        "async": "1.5.2",
+        "glob-to-regexp": "0.1.0"
+      }
     },
     "node-gyp": {
       "version": "3.8.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "animate.css": "^3.7.0",
     "bootstrap": "^4.1.3",
     "jquery": "^3.3.1",
+    "node-glob": "^1.2.0",
     "owl.carousel": "^2.3.4",
     "popper.js": "^1.14.4"
   }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -62,7 +62,6 @@ module.exports = (env, options) => ({
     }),
     new CleanWebpackPlugin(["dist"]),
     ...globSync('src/**/*.html').map((fileName) => {
-      console.log(fileName);
       return new HtmlWebpackPlugin({
         template: fileName,
         inject: "body",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,6 +3,7 @@ const CleanWebpackPlugin = require("clean-webpack-plugin");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const webpack = require("webpack");
 const path = require("path");
+const globSync = require('glob').sync;
 
 module.exports = (env, options) => ({
   entry: ["./src/index.js"],
@@ -60,90 +61,13 @@ module.exports = (env, options) => ({
       filename: "css/[name].[contenthash].css",
     }),
     new CleanWebpackPlugin(["dist"]),
-    new HtmlWebpackPlugin({
-      template: "src/index.html",
-      inject: "body",
-      filename: "index.html"
-    }),
-    new HtmlWebpackPlugin({
-      template: "src/about.html",
-      inject: "body",
-      filename: "about.html"
-    }),
-    new HtmlWebpackPlugin({
-      template: "src/about/our-history.html",
-      inject: "body",
-      filename: "about/our-history.html"
-    }),
-    new HtmlWebpackPlugin({
-      template: "src/administration.html",
-      inject: "body",
-      filename: "administration.html"
-    }),
-    new HtmlWebpackPlugin({
-      template: "src/contact.html",
-      inject: "body",
-      filename: "contact.html"
-    }),
-    new HtmlWebpackPlugin({
-      template: "src/gallery.html",
-      inject: "body",
-      filename: "gallery.html"
-    }),
-    new HtmlWebpackPlugin({
-      template: "src/studies/btech-computer-science-engg.html",
-      inject: "body",
-      filename: "studies/btech-computer-science-engg.html"
-    }),
-    new HtmlWebpackPlugin({
-      template: "src/studies/btech-mechanical-engg.html",
-      inject: "body",
-      filename: "studies/btech-mechanical-engg.html"
-    }),
-    new HtmlWebpackPlugin({
-      template: "src/studies/btech-electrical-and-electronics-engg.html",
-      inject: "body",
-      filename: "studies/btech-electrical-and-electronics-engg.html"
-    }),
-    new HtmlWebpackPlugin({
-      template: "src/studies/btech-electronics-and-communication-engg.html",
-      inject: "body",
-      filename: "studies/btech-electronics-and-communication-engg.html"
-    }),
-    new HtmlWebpackPlugin({
-      template: "src/studies/mtech-thermal-engg.html",
-      inject: "body",
-      filename: "studies/mtech-thermal-engg.html"
-    }),
-    new HtmlWebpackPlugin({
-      template: "src/studies/academic-programs.html",
-      inject: "body",
-      filename: "studies/academic-programs.html"
-    }),
-    new HtmlWebpackPlugin({
-      template: "src/cea-experience/stories.html",
-      inject: "body",
-      filename: "cea-experience/stories.html"
-    }),
-    new HtmlWebpackPlugin({
-      template: "src/news-and-events.html",
-      inject: "body",
-      filename: "news-and-events.html"
-    }),
-    new HtmlWebpackPlugin({
-        template: "src/about/faculty.html",
+    ...globSync('src/**/*.html').map((fileName) => {
+      console.log(fileName);
+      return new HtmlWebpackPlugin({
+        template: fileName,
         inject: "body",
-        filename: "faculty.html"
-      }),
-    new HtmlWebpackPlugin({
-        template: "src/about/our-commitment.html",
-        inject: "body",
-        filename: "our-commitment.html"
-    }),
-    new HtmlWebpackPlugin({
-      template: "src/campus-life/clubs-at-cea.html",
-      inject: "body",
-      filename: "campus-life/clubs-at-cea.html"
+        filename: fileName.replace('src/', '')
+      })
     }),
     new webpack.ProvidePlugin({
       $: "jquery",


### PR DESCRIPTION
The purpose of this pull request is to address https://github.com/ceadoor/cea.ac.in/issues/114. 

This will remove the requirement to add an entry for each HTML page implemented.

This PR adds an developer dependency of `node-glob`.

This still has the down fall that new files added whilst webpack is running aren't picked up and considered within livereloading.